### PR TITLE
Make publishing to Npm optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,16 @@ The aim of this module is to keep a repository in a state where if the `version`
 Once the package has been installed, it may be used from the terminal:
 
 ```shell
-npm-bump releaseType
+  -t, --release-type    Type of the release, "patch", "minor" or "major"
+  -r, --remote          The remote repository (default: "origin")
+  -b, --branch          The branch to perform the release on (default: "master")
+  --ignore-npm          Boolean flag for omitting the publishing to Npm
+```
+
+So to simply release a version on branch `master` to the remote `origin`, do:
+
+```shell
+npm-bump -t releaseType
 ```
 
 where `releaseType` is one of: `major`, `minor` and `patch`.
@@ -40,6 +49,13 @@ To use as a module, do the following:
 ```js
 var npmBump = require('npm-bump');
 npmBump(releaseType);
+```
+
+Or without publishing to Npm:
+
+```js
+var npmBump = require('npm-bump');
+npmBump(releaseType, false);
 ```
 
 Regardless of using the package as a binary or a module, invoking the above code will result in:
@@ -70,12 +86,12 @@ You can optionally pass the remote name and the branch name to be used. By defau
 
 1. When using from shell:
 ```shell
-npm-bump releaseType remoteName branch
+npm-bump -t releaseType -r remoteName -b branch
 ```
 2. When using as a library:
 ```js
 var npmBump = require('npm-bump').custom(remoteName, branch);
-npmBump(releaseType);
+npmBump(releaseType, [<ignoreNpm>]);
 ```
 
 ## Supported Node.js versions

--- a/bin/npm-bump
+++ b/bin/npm-bump
@@ -2,10 +2,14 @@
 
 'use strict';
 
-const args = process.argv.slice(2);
+const args = require('minimist')(process.argv.slice(2), {
+    '--branch': '-b',
+    '--remote': '-r',
+    '--release-type': '-t'
+});
 
 try {
-    require('../lib/cli').custom(args[1], args[2])(args[0]);
+    require('../lib/cli').custom(args.r, args.b)(args.t, args['ignore-npm']);
 } catch (error) {
     if (error.name === 'UsageError') {
         console.error(error.message);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,8 +17,9 @@ const createNpmBump = (remoteName, branch) => {
         }
     };
 
-    return releaseType => {
+    return (releaseType, _ignoreNpm) => {
         const isPrerelease = ['major', 'minor', 'patch'].indexOf(releaseType) === -1;
+        const ignoreNpm = !!_ignoreNpm;
 
         const getHashFor = branchName => {
             try {
@@ -89,9 +90,11 @@ const createNpmBump = (remoteName, branch) => {
                 if (answers.shouldProceed) {
                     // Push & publish the tag.
                     run(`git checkout ${ quote(newStableVersion) } 2>/dev/null`);
-                    run(`npm publish ${ quote(getRootPath()) }${
-                        isPrerelease ? ` --tag ${ quote(releaseType) }` : '' }`
-                    );
+                    if (!ignoreNpm) {
+                        run(`npm publish ${ quote(getRootPath()) }${
+                            isPrerelease ? ` --tag ${ quote(releaseType) }` : '' }`
+                        );
+                    }
                     run(`git push ${ quote(remoteName) } ${ quote(newStableVersion) }`);
 
                     // Push the latest commit.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   ],
   "dependencies": {
     "inquirer": "^1.1.2",
+    "minimist": "^1.2.0",
     "semver": "^5.3.0",
     "shell-quote": "^1.6.1"
   },


### PR DESCRIPTION
Hi.

I really like this module, but me and my team need to be able to turn off the publishing to Npm in order to be able to use `npm-bump`.

Let me know, what you think of the adjustments.

Cheers!
